### PR TITLE
fix: include service, protocol and server in SRV TXT companion domain

### DIFF
--- a/src/sync.go
+++ b/src/sync.go
@@ -125,7 +125,10 @@ func buildTXTRegistryRecords(prefix string, desired map[string]DNSRecord) []DNSR
 
 		txtDomain := record.Domain
 		if record.Type == recordTypeSRV {
-			txtDomain = strings.ReplaceAll(txtDomain, "_", "")
+			// Include service, protocol, and target (server) in the TXT domain
+			service := strings.TrimPrefix(record.SrvService, "_")
+			protocol := strings.TrimPrefix(record.SrvProtocol, "_")
+			txtDomain = service + "." + protocol + "." + record.SrvTarget + "." + record.Domain
 		}
 
 		records = append(records, DNSRecord{


### PR DESCRIPTION
Closes #1 

The TXT companion entry for SRV records was missing the service name and server information. For example, with these labels:
  - unifi.dns.2.domain=domain.com
  - unifi.dns.2.server=test
  - unifi.dns.2.service=cadvisor
  - unifi.dns.2.protocol=_tcp
  - unifi.dns.2.port=8088
  - unifi.dns.2.type=SRV

The TXT companion was generating 'docker-test.domain.com' but should generate 'docker-test.cadvisor.tcp.test.domain.com' to match the full SRV record domain structure.

Fixes the buildTXTRegistryRecords function to include service, protocol, and target server components when constructing the TXT domain for SRV records.